### PR TITLE
Add keyboard support and accessibility support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 test/output
 node_modules
 bower_components
-coverage/
+coverage

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "tests"
   ],
   "dependencies": {
-    "vui-dropdown": "~0.0.1"
+    "vui-dropdown": "~0.0.4"
   }
 }

--- a/dist/dropdownMenu.css
+++ b/dist/dropdownMenu.css
@@ -54,10 +54,12 @@
 
 .dropdown-item {
   padding: 8px 15px 8px 15px;
+  outline-style: none;
 }
 
 .dropdown-item.disabled {
   padding: 8px 15px 8px 15px;
+  outline-style: none;
   color: #7c8695;
 }
 

--- a/dist/dropdownMenu.js
+++ b/dist/dropdownMenu.js
@@ -48,6 +48,8 @@ var Menu = React.createClass({
 		if (event.keyCode === keys.ENTER || event.keyCode === keys.SPACE) {
 			if (this.state.isListVisible) {
 				this.selectItem();
+				this.hide();
+				React.findDOMNode(this.refs.menuButton).focus();
 			} else {
 				this.show();
 			}
@@ -87,7 +89,12 @@ var Menu = React.createClass({
 	},
 
 	selectItem: function selectItem() {
-		this.refs.menuList.selectItem();
+		if (this.state.selectedItem !== -1) {
+			var menuItem = this.props.items[this.state.selectedItem];
+			if (!menuItem.isDisabled) {
+				menuItem.onClick();
+			}
+		}
 	},
 
 	selectFocus: function selectFocus(index) {

--- a/dist/dropdownMenu.js
+++ b/dist/dropdownMenu.js
@@ -1,36 +1,133 @@
 'use strict';
 
 var React = require('react'),
-    MenuList = require('./menuList');
+    MenuList = require('./menuList'),
+    keys = require('./keys');
 
 var Menu = React.createClass({
 	displayName: 'Menu',
 
+	componentDidMount: function componentDidMount() {
+		React.findDOMNode(this.refs.menuButton).addEventListener('blur', this.onBlur, true);
+	},
+
+	componentWillUnmount: function componentWillUnmount() {
+		React.findDOMNode(this.refs.menuButton).removeEventListener('blur', this.onBlur, true);
+	},
+
 	getInitialState: function getInitialState() {
 		return {
-			isListVisible: false
+			isListVisible: false,
+			selectedItem: -1
 		};
 	},
 
 	show: function show() {
+		var focusFirstItem = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
+
 		this.setState({
-			isListVisible: true
+			isListVisible: true,
+			selectedItem: focusFirstItem ? 0 : -1
 		});
 		document.addEventListener('click', this.hide);
 	},
 
 	hide: function hide() {
 		this.setState({
-			isListVisible: false
+			isListVisible: false,
+			selectedItem: -1
 		});
 		document.removeEventListener('click', this.hide);
+	},
+
+	onClick: function onClick() {
+		this.show();
+	},
+
+	handleKeyDown: function handleKeyDown(event) {
+		if (event.keyCode === keys.ENTER || event.keyCode === keys.SPACE) {
+			if (this.state.isListVisible) {
+				this.selectItem();
+			} else {
+				this.show();
+			}
+		} else if (event.keyCode === keys.ESCAPE) {
+			this.hide();
+			React.findDOMNode(this.refs.menuButton).focus();
+		} else if (event.keyCode === keys.DOWN) {
+			if (!this.state.isListVisible) {
+				this.show(true);
+			} else {
+				this.moveFocusDown();
+			}
+		} else if (event.keyCode === keys.UP) {
+			this.moveFocusUp();
+		}
+	},
+
+	moveFocusUp: function moveFocusUp() {
+		var newIndex = this.state.selectedItem - 1;
+
+		if (newIndex < 0) {
+			newIndex = this.props.items.length - 1;
+		}
+		this.setState({
+			selectedItem: newIndex
+		});
+	},
+
+	moveFocusDown: function moveFocusDown() {
+		var newIndex = this.state.selectedItem + 1;
+		if (newIndex >= this.props.items.length) {
+			newIndex = 0;
+		}
+		this.setState({
+			selectedItem: newIndex
+		});
+	},
+
+	selectItem: function selectItem() {
+		this.refs.menuList.selectItem();
+	},
+
+	selectFocus: function selectFocus(index) {
+		if (this.state.selectedItem !== index) {
+			this.setState({
+				selectedItem: index
+			});
+		}
+	},
+
+	onBlur: function onBlur(event) {
+		if (event.relatedTarget && event.relatedTarget.parentNode !== React.findDOMNode(this.refs.menuList)) {
+			// losing focus and focus not in the menu list either
+			this.hide();
+		}
 	},
 
 	render: function render() {
 		return React.createElement(
 			'div',
-			{ className: 'dropdown-arrow-icon', onClick: this.show },
-			React.createElement(MenuList, { isListVisible: this.state.isListVisible, items: this.props.items })
+			{
+				className: 'dropdown-arrow-icon',
+				onClick: this.onClick,
+				onKeyDown: this.handleKeyDown,
+				'aria-haspopup': true,
+				role: 'button',
+				'aria-expanded': this.state.isListVisible,
+				tabIndex: '0',
+				ref: 'menuButton'
+			},
+			React.createElement(MenuList, {
+				closeMenu: this.hide,
+				isListVisible: this.state.isListVisible,
+				items: this.props.items,
+				selectedItem: this.state.selectedItem,
+				role: 'menu',
+				'aria-visible': this.state.isListVisible,
+				selectFocus: this.selectFocus,
+				ref: 'menuList'
+			})
 		);
 	}
 });

--- a/dist/keys.js
+++ b/dist/keys.js
@@ -1,0 +1,13 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+exports["default"] = {
+	ENTER: 13,
+	ESCAPE: 27,
+	SPACE: 32,
+	UP: 38,
+	DOWN: 40
+};
+module.exports = exports["default"];

--- a/dist/menuItem.js
+++ b/dist/menuItem.js
@@ -7,15 +7,24 @@ var MenuItem = React.createClass({
 	displayName: 'MenuItem',
 
 	propTypes: {
+		id: React.PropTypes.number,
 		text: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		isDisabled: React.PropTypes.bool
+		isDisabled: React.PropTypes.bool,
+		isSelected: React.PropTypes.bool,
+		selectFocus: React.PropTypes.func
 	},
 
 	getDefaultProps: function getDefaultProps() {
 		return {
-			isDisabled: false
+			isDisabled: false,
+			isSelected: false
 		};
+	},
+
+	componentDidUpdate: function componentDidUpdate() {
+		if (this.props.isSelected) {
+			React.findDOMNode(this.refs.listItem).focus();
+		}
 	},
 
 	select: function select(event) {
@@ -25,11 +34,25 @@ var MenuItem = React.createClass({
 		event.stopPropagation();
 	},
 
+	onMouseMove: function onMouseMove() {
+		if (this.props.selectFocus && !this.props.isSelected) {
+			this.props.selectFocus(this.props.id);
+		}
+	},
+
 	render: function render() {
-		var className = classNames('dropdown-item', { disabled: this.props.isDisabled });
+		var className = classNames('dropdown-item', { disabled: this.props.isDisabled }, { selected: this.props.isSelected });
 		return React.createElement(
-			'div',
-			{ className: className, onClick: this.select },
+			'li',
+			{
+				ref: 'listItem',
+				className: className,
+				onClick: this.select,
+				role: 'menuitem',
+				tabIndex: '-1',
+				onMouseMove: this.onMouseMove,
+				'aria-disabled': this.props.isDisabled
+			},
 			this.props.text
 		);
 	}

--- a/dist/menuList.js
+++ b/dist/menuList.js
@@ -8,16 +8,9 @@ var MenuList = React.createClass({
 
 	propTypes: {
 		isListVisible: React.PropTypes.bool,
-		menuItems: React.PropTypes.array,
+		items: React.PropTypes.array,
 		selectedItem: React.PropTypes.number,
 		selectFocus: React.PropTypes.func
-	},
-
-	selectItem: function selectItem() {
-		if (this.props.selectedItem !== -1) {
-			var listNode = React.findDOMNode(this.refs.menuList);
-			listNode.children[this.props.selectedItem].click();
-		}
 	},
 
 	render: function render() {

--- a/dist/menuList.js
+++ b/dist/menuList.js
@@ -7,7 +7,17 @@ var MenuList = React.createClass({
 	displayName: 'MenuList',
 
 	propTypes: {
-		isListVisible: React.PropTypes.bool
+		isListVisible: React.PropTypes.bool,
+		menuItems: React.PropTypes.array,
+		selectedItem: React.PropTypes.number,
+		selectFocus: React.PropTypes.func
+	},
+
+	selectItem: function selectItem() {
+		if (this.props.selectedItem !== -1) {
+			var listNode = React.findDOMNode(this.refs.menuList);
+			listNode.children[this.props.selectedItem].click();
+		}
 	},
 
 	render: function render() {
@@ -19,7 +29,7 @@ var MenuList = React.createClass({
 		}
 		return React.createElement(
 			'ul',
-			{ className: listClassName },
+			{ className: listClassName, ref: 'menuList', role: 'menulist', 'aria-visible': this.props.isListVisible },
 			this.renderListItems()
 		);
 	},
@@ -29,11 +39,14 @@ var MenuList = React.createClass({
 		if (this.props.items) {
 			for (var i = 0; i < this.props.items.length; i++) {
 				var item = this.props.items[i];
-				items.push(React.createElement(
-					'li',
-					null,
-					React.createElement(MenuItem, { text: item.text, onClick: item.onClick, isDisabled: item.isDisabled })
-				));
+				items.push(React.createElement(MenuItem, {
+					text: item.text,
+					onClick: item.onClick,
+					isDisabled: item.isDisabled,
+					isSelected: i === this.props.selectedItem,
+					selectFocus: this.props.selectFocus,
+					id: i
+				}));
 			}
 		}
 		return items;

--- a/src/dropdownMenu.jsx
+++ b/src/dropdownMenu.jsx
@@ -42,6 +42,8 @@ var Menu = React.createClass( {
 		if (event.keyCode === keys.ENTER || event.keyCode === keys.SPACE) {
 			if (this.state.isListVisible) {
 				this.selectItem();
+				this.hide();
+				React.findDOMNode(this.refs.menuButton).focus();
 			} else {
 				this.show();
 			}
@@ -85,8 +87,12 @@ var Menu = React.createClass( {
 	},
 
 	selectItem: function() {
-		this.refs.menuList.selectItem();
-
+		if ( this.state.selectedItem !== -1) {
+			let menuItem = this.props.items[this.state.selectedItem];
+			if ( !menuItem.isDisabled ) {
+				menuItem.onClick();
+			}
+		}
 	},
 
 	selectFocus: function(index) {

--- a/src/dropdownMenu.jsx
+++ b/src/dropdownMenu.jsx
@@ -1,31 +1,133 @@
 var React = require('react'),
-	MenuList = require('./menuList');
+	MenuList = require('./menuList'),
+	keys = require('./keys');
 
 var Menu = React.createClass( {
+	componentDidMount: function() {
+		React.findDOMNode(this.refs.menuButton).addEventListener('blur', this.onBlur, true);
+	},
+
+	componentWillUnmount: function() {
+		React.findDOMNode(this.refs.menuButton).removeEventListener('blur', this.onBlur, true);
+	},
+
 	getInitialState: function() {
 		return {
-			isListVisible: false
+			isListVisible: false,
+			selectedItem: -1
 		};
 	},
 
-	show: function() {
+	show: function( focusFirstItem = false) {
 		this.setState({
-			isListVisible: true
+			isListVisible: true,
+			selectedItem: focusFirstItem ? 0 : -1
 		});
 		document.addEventListener('click', this.hide);
 	},
 
 	hide: function() {
 		this.setState({
-			isListVisible: false
+			isListVisible: false,
+			selectedItem: -1
 		});
 		document.removeEventListener('click', this.hide);
 	},
 
+	onClick: function() {
+		this.show( );
+	},
+
+	handleKeyDown: function( event ) {
+		if (event.keyCode === keys.ENTER || event.keyCode === keys.SPACE) {
+			if (this.state.isListVisible) {
+				this.selectItem();
+			} else {
+				this.show();
+			}
+		} else if (event.keyCode === keys.ESCAPE ) {
+			this.hide();
+			React.findDOMNode(this.refs.menuButton).focus();
+		} else if ( event.keyCode === keys.DOWN ) {
+			if (!this.state.isListVisible) {
+				this.show( true );
+			} else {
+				this.moveFocusDown();
+			}
+		} else if ( event.keyCode === keys.UP ) {
+			this.moveFocusUp();
+		}
+	},
+
+	moveFocusUp: function(  ) {
+		var newIndex = this.state.selectedItem - 1;
+
+		if ( newIndex < 0 ) {
+			newIndex = this.props.items.length - 1;
+		}
+		this.setState(
+			{
+				selectedItem: newIndex
+			}
+		);
+	},
+
+	moveFocusDown: function(  ) {
+		var newIndex = this.state.selectedItem + 1;
+		if ( newIndex >= this.props.items.length) {
+			newIndex = 0;
+		}
+		this.setState(
+			{
+				selectedItem: newIndex
+			}
+		);
+	},
+
+	selectItem: function() {
+		this.refs.menuList.selectItem();
+
+	},
+
+	selectFocus: function(index) {
+		if (this.state.selectedItem !== index) {
+			this.setState(
+				{
+					selectedItem: index
+				}
+			);
+		}
+	},
+
+	onBlur: function( event ) {
+		if ( event.relatedTarget && event.relatedTarget.parentNode !== React.findDOMNode(this.refs.menuList)) {
+			// losing focus and focus not in the menu list either
+			this.hide();
+		}
+	},
+
 	render: function() {
 		return (
-			<div className="dropdown-arrow-icon" onClick={this.show}>
-				<MenuList isListVisible={this.state.isListVisible} items={this.props.items}/>
+			<div
+				className = "dropdown-arrow-icon"
+				onClick = { this.onClick }
+				onKeyDown = { this.handleKeyDown }
+				aria-haspopup = { true }
+				role = "button"
+				aria-expanded = { this.state.isListVisible }
+				tabIndex = "0"
+				ref = "menuButton"
+			>
+				<MenuList
+					closeMenu = { this.hide }
+					isListVisible = { this.state.isListVisible }
+					items = { this.props.items }
+					selectedItem = { this.state.selectedItem }
+					role = "menu"
+					aria-visible = { this.state.isListVisible }
+					selectFocus = { this.selectFocus }
+					ref = "menuList"
+				/>
 			</div>
 		);
 	}

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,0 +1,7 @@
+export default {
+	ENTER: 13,
+	ESCAPE: 27,
+	SPACE: 32,
+	UP: 38,
+	DOWN: 40
+};

--- a/src/menuItem.jsx
+++ b/src/menuItem.jsx
@@ -4,15 +4,24 @@ var React = require('react'),
 var MenuItem = React.createClass({
 
 	propTypes: {
+		id: React.PropTypes.number,
 		text: React.PropTypes.string,
-		onClick: React.PropTypes.func,
-		isDisabled: React.PropTypes.bool
+		isDisabled: React.PropTypes.bool,
+		isSelected: React.PropTypes.bool,
+		selectFocus: React.PropTypes.func
 	},
 
 	getDefaultProps: function() {
 		return {
-			isDisabled: false
+			isDisabled: false,
+			isSelected: false
 		};
+	},
+
+	componentDidUpdate: function() {
+		if ( this.props.isSelected ) {
+			React.findDOMNode( this.refs.listItem ).focus();
+		}
 	},
 
 	select: function( event ) {
@@ -22,12 +31,26 @@ var MenuItem = React.createClass({
 		event.stopPropagation();
 	},
 
+	onMouseMove: function() {
+		if ( this.props.selectFocus && !this.props.isSelected ) {
+			this.props.selectFocus( this.props.id );
+		}
+	},
+
 	render: function() {
-		var className = classNames( 'dropdown-item', { disabled: this.props.isDisabled } );
+		var className = classNames( 'dropdown-item', { disabled: this.props.isDisabled }, { selected: this.props.isSelected } );
 		return (
-			<div className={className} onClick={this.select} >
-				{this.props.text}
-			</div>
+			<li
+				ref = "listItem"
+				className = { className }
+				onClick = { this.select }
+				role = "menuitem"
+				tabIndex = "-1"
+				onMouseMove = { this.onMouseMove }
+				aria-disabled = {this.props.isDisabled}
+			>
+				{ this.props.text }
+			</li>
 		);
 	}
 });

--- a/src/menuList.jsx
+++ b/src/menuList.jsx
@@ -5,16 +5,9 @@ var MenuList = React.createClass({
 
 	propTypes: {
 		isListVisible: React.PropTypes.bool,
-		menuItems: React.PropTypes.array,
+		items: React.PropTypes.array,
 		selectedItem: React.PropTypes.number,
 		selectFocus: React.PropTypes.func
-	},
-
-	selectItem: function() {
-		if ( this.props.selectedItem !== -1 ) {
-			var listNode = React.findDOMNode( this.refs.menuList );
-			listNode.children[this.props.selectedItem].click();
-		}
 	},
 
 	render: function() {

--- a/src/menuList.jsx
+++ b/src/menuList.jsx
@@ -4,29 +4,47 @@ var React = require('react'),
 var MenuList = React.createClass({
 
 	propTypes: {
-		isListVisible: React.PropTypes.bool
+		isListVisible: React.PropTypes.bool,
+		menuItems: React.PropTypes.array,
+		selectedItem: React.PropTypes.number,
+		selectFocus: React.PropTypes.func
+	},
+
+	selectItem: function() {
+		if ( this.props.selectedItem !== -1 ) {
+			var listNode = React.findDOMNode( this.refs.menuList );
+			listNode.children[this.props.selectedItem].click();
+		}
 	},
 
 	render: function() {
 		var listClassName;
-		if (this.props.isListVisible) {
+		if ( this.props.isListVisible ) {
 			listClassName = 'dropdown-list-show';
 		} else {
 			listClassName = 'dropdown-list-hidden';
 		}
 		return (
-			<ul className={listClassName}>
-				{this.renderListItems()}
+			<ul className={listClassName} ref="menuList" role="menulist" aria-visible={this.props.isListVisible}>
+				{ this.renderListItems() }
 			</ul>
 		);
 	},
 
 	renderListItems: function() {
 		var items = [];
-		if (this.props.items) {
+		if ( this.props.items ) {
 			for (var i = 0; i < this.props.items.length; i++) {
 				var item = this.props.items[i];
-				items.push(<li><MenuItem text={item.text} onClick={item.onClick} isDisabled={item.isDisabled} /></li>);
+				items.push(
+					<MenuItem
+						text = { item.text }
+						onClick = { item.onClick }
+						isDisabled = { item.isDisabled }
+						isSelected = { i === this.props.selectedItem }
+						selectFocus = { this.props.selectFocus }
+						id = { i }
+					/>);
 			}
 		}
 		return items;

--- a/test/unit/dropdownMenu-tests.js
+++ b/test/unit/dropdownMenu-tests.js
@@ -1,18 +1,46 @@
 'use strict';
 
 jest.dontMock('../../dist/dropdownMenu');
+jest.dontMock('../../dist/menuList');
+jest.dontMock('../../dist/menuItem');
 
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
+import keys from '../../src/keys.js';
 
 const DropdownMenu = require( '../../index');
 
+
+
 describe( 'menu tests', function() {
+
+	const menuItems = [
+		{
+			text: 'First menu item',
+			onClick: onClickTest
+		},
+		{
+			text: 'Second menu item',
+			isDisabled: true,
+			onClick: onClickTest
+		}
+	];
+
+	var clickCount = 0;
+
+	function onClickTest() {
+		clickCount += 1;
+	}
+
+	beforeEach( function() {
+		clickCount = 0;
+	});
+
 	it( 'menu has class name', function() {
 
 		var menuTestDOM = TestUtils.renderIntoDocument(
-			<DropdownMenu.DropdownMenu/>
+			<DropdownMenu.DropdownMenu items={menuItems}/>
 		);
 
 		expect(ReactDOM.findDOMNode(menuTestDOM).className).toBe('dropdown-arrow-icon');
@@ -35,5 +63,153 @@ describe( 'menu tests', function() {
 			ReactDOM.findDOMNode(menuTestDOM)
 		);
 		expect(menuTestDOM.state.isListVisible).toBe(true);
+	});
+
+	it( 'menu opened with enter', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu/>
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.ENTER
+			}
+		);
+		expect(menuTestDOM.state.isListVisible).toBe(true);
+		expect(menuTestDOM.state.selectedItem).toBe(-1);
+	});
+
+	it ( 'menu opened with down arrow', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu/>
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		expect(menuTestDOM.state.isListVisible).toBe(true);
+		expect(menuTestDOM.state.selectedItem).toBe(0);
+	});
+
+	it ( 'menu closed with escape', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu/>
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		expect(menuTestDOM.state.isListVisible).toBe(true);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.ESCAPE
+			}
+		);
+		expect(menuTestDOM.state.isListVisible).toBe(false);
+	});
+
+	it ( 'set focus directly', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu/>
+		);
+		menuTestDOM.selectFocus(1);
+		expect(menuTestDOM.state.selectedItem).toBe(1);
+	});
+
+	it ( 'select menu item', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu items={menuItems}/>
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.ENTER
+			}
+		);
+		expect(clickCount).toBe(1);
+	});
+
+	it ( 'menu rollover down', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu items={menuItems}/>
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		expect(menuTestDOM.state.selectedItem).toBe(0);
+	});
+
+	it ( 'menu rollover up', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu items={menuItems}/>
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.UP
+			}
+		);
+		expect(menuTestDOM.state.selectedItem).toBe(1);
+	});
+
+	it ( 'menu select disabled', function() {
+		var menuTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.DropdownMenu items={menuItems}/>
+		);
+		var someLink = TestUtils.renderIntoDocument(
+			<a href="http://www.brightspace.com">here</a>
+		);
+
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.DOWN
+			}
+		);
+		TestUtils.Simulate.keyDown(
+			ReactDOM.findDOMNode(menuTestDOM),
+			{
+				keyCode: keys.ENTER
+			}
+		);
+		expect(clickCount).toBe(0);
 	});
 });

--- a/test/unit/menuItem-tests.js
+++ b/test/unit/menuItem-tests.js
@@ -54,4 +54,18 @@ describe('menuItem', function() {
 		expect(ReactDOM.findDOMNode(menuItemTestDOM).className).toBe('dropdown-item');
 
 	});
+
+	it ( 'menu item mouse move', function() {
+		var itemId = 0;
+		var focusMock = function( id ) {
+			itemId = id;
+		};
+		var menuItemTestDOM = TestUtils.renderIntoDocument(
+			<DropdownMenu.MenuItem text="menu test" id={55} selectFocus={focusMock}/>
+		);
+		TestUtils.Simulate.mouseMove(
+			ReactDOM.findDOMNode(menuItemTestDOM)
+		);
+		expect(itemId).toBe(55);
+	});
 });


### PR DESCRIPTION
Enter opens menu or selects the currently highlighted item
Down arrow opens and selects first item or selects the next item
Up arrow selects the previous item
Escape closes menu

Aria tags to support screen readers, tested using nvda in Firefox
Menu items are selected by setting them as being focused
Mousing over an item will cause it to become focused.